### PR TITLE
fix NPE for maven multimodule projects

### DIFF
--- a/src/ca/weblite/asm/WLMirahCompiler.java
+++ b/src/ca/weblite/asm/WLMirahCompiler.java
@@ -269,7 +269,7 @@ public class WLMirahCompiler {
                         Logger.getLogger(WLMirahCompiler.class.getName()).log(Level.SEVERE, null, ex);
                     } finally {
                         try {
-                            zip.close();
+                            if ( zip != null ) zip.close();
                         } catch (IOException ex) {
                             Logger.getLogger(WLMirahCompiler.class.getName()).log(Level.SEVERE, null, ex);
                         }


### PR DESCRIPTION
In case of maven multimodule project with dependencies module dependencies jar could be missed raising FileNotFoundException properly catched but triggering NPE in finally block.
